### PR TITLE
feat(core): add reproducibility pack core modules

### DIFF
--- a/src/lexprep/length.py
+++ b/src/lexprep/length.py
@@ -1,0 +1,48 @@
+"""Length feature: adds length_chars column (Unicode codepoint count)."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import asdict, dataclass
+from typing import List, Optional
+
+# Documented method for reproducibility
+LENGTH_METHOD = "unicode_codepoints"
+
+
+@dataclass
+class LengthDistribution:
+    """Summary statistics for token lengths."""
+
+    min: int
+    max: int
+    mean: float
+    median: float
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def compute_length_chars(words: List[str]) -> List[int]:
+    """Return Unicode codepoint count for each word.
+
+    Uses Python ``len()`` which counts Unicode codepoints (not bytes).
+    Empty or whitespace-only tokens receive length 0.
+    """
+    return [len(w) if w and w.strip() else 0 for w in words]
+
+
+def length_distribution(lengths: List[int]) -> Optional[LengthDistribution]:
+    """Compute summary stats for a list of lengths.
+
+    Returns ``None`` if no valid (>0) lengths exist.
+    """
+    valid = [ln for ln in lengths if ln > 0]
+    if not valid:
+        return None
+    return LengthDistribution(
+        min=min(valid),
+        max=max(valid),
+        mean=round(statistics.mean(valid), 2),
+        median=round(statistics.median(valid), 2),
+    )

--- a/src/lexprep/manifest.py
+++ b/src/lexprep/manifest.py
@@ -1,0 +1,258 @@
+"""Run manifest generation for reproducibility packs (D2)."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from lexprep import __version__
+
+# ---------------------------------------------------------------------------
+# Tool Registry — single source of truth for tool names + stable columns
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Describes a tool's manifest metadata."""
+
+    manifest_name: str
+    stable_added_columns: tuple[str, ...]
+    supports_summary: bool = False
+    supports_reproducibility: bool = False
+
+
+TOOL_REGISTRY: Dict[str, ToolSpec] = {
+    # Language tools — Persian
+    "fa_g2p": ToolSpec("g2p", ("pronunciation", "g2p_error")),
+    "fa_syllables": ToolSpec(
+        "syllable_count", ("syllabified", "syllable_count"), supports_summary=True
+    ),
+    "fa_syllables_phonetic": ToolSpec(
+        "syllable_count", ("pronunciation", "syllable_count"), supports_summary=True
+    ),
+    "fa_pos": ToolSpec("pos_tagging", ("normalized", "pos", "lemma"), supports_summary=True),
+    # Language tools — English
+    "en_g2p": ToolSpec("g2p", ("pronunciation", "g2p_error")),
+    "en_syllables": ToolSpec("syllable_count", ("syllable_count",), supports_summary=True),
+    "en_pos": ToolSpec("pos_tagging", ("pos", "tag", "lemma"), supports_summary=True),
+    # Language tools — Japanese
+    "ja_pos_unidic": ToolSpec(
+        "pos_tagging", ("pos", "pos_english", "lemma"), supports_summary=True
+    ),
+    "ja_pos_stanza": ToolSpec("pos_tagging", ("pos",), supports_summary=True),
+    # Universal tools
+    "length": ToolSpec("length", ("length_chars",), supports_summary=True),
+    # Sampling tools
+    "stratified": ToolSpec("stratified_sampling", ("bin_id",), supports_reproducibility=True),
+    "shuffle": ToolSpec("row_shuffle", (), supports_reproducibility=True),
+}
+
+
+def registry_key(language: Optional[str], tool: str) -> str:
+    """Build a registry key from language + tool."""
+    if language:
+        key = f"{language}_{tool}"
+        if key in TOOL_REGISTRY:
+            return key
+    # Fall back to tool-only key
+    if tool in TOOL_REGISTRY:
+        return tool
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Citation — synced with CITATION.cff
+# ---------------------------------------------------------------------------
+
+CITATION_INFO = {
+    "authors": [
+        {
+            "family_names": "Mazaherizaveh",
+            "given_names": "Sajjad",
+            "orcid": "https://orcid.org/0009-0001-0465-0444",
+        }
+    ],
+    "title": "LexPrep",
+    "doi": "10.5281/zenodo.18713755",
+    "url": "https://github.com/sajjad-mazaheri/lexprep",
+    "license": "MIT",
+    "version": __version__,
+}
+
+
+# ---------------------------------------------------------------------------
+# Timestamp utility
+# ---------------------------------------------------------------------------
+
+
+def utc_now() -> datetime:
+    """Return current UTC datetime (single source for consistency)."""
+    return datetime.now(timezone.utc)
+
+
+def format_timestamp_filename(ts: datetime) -> str:
+    """Format timestamp for ZIP filenames: ``YYYYMMDDTHHMMSSZ``."""
+    return ts.strftime("%Y%m%dT%H%M%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Basename sanitisation
+# ---------------------------------------------------------------------------
+
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f\s]+')
+
+
+def sanitize_basename(name: str) -> str:
+    """Remove/replace characters unsafe for filenames."""
+    clean = _UNSAFE_CHARS.sub("_", name)
+    return clean.strip("_") or "output"
+
+
+# ---------------------------------------------------------------------------
+# Library version detection
+# ---------------------------------------------------------------------------
+
+
+def get_library_version(package_name: str) -> str:
+    """Get installed version of a package via importlib.metadata."""
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def get_libraries_for_tool(language: Optional[str], tool: str) -> List[Dict[str, str]]:
+    """Return list of ``{name, version}`` dicts for the libraries used by a tool."""
+    libs: List[Dict[str, str]] = []
+
+    if language == "fa":
+        if tool in ("g2p", "syllables_phonetic"):
+            libs.append({"name": "PersianG2p", "version": get_library_version("PersianG2p")})
+        if tool == "pos":
+            libs.append({"name": "stanza", "version": get_library_version("stanza")})
+    elif language == "en":
+        if tool == "g2p":
+            libs.append({"name": "g2p-en", "version": get_library_version("g2p-en")})
+        if tool == "syllables":
+            libs.append({"name": "pyphen", "version": get_library_version("pyphen")})
+        if tool == "pos":
+            libs.append({"name": "spacy", "version": get_library_version("spacy")})
+    elif language == "ja":
+        if tool in ("pos_unidic",):
+            libs.append({"name": "fugashi", "version": get_library_version("fugashi")})
+            libs.append({"name": "unidic-lite", "version": get_library_version("unidic-lite")})
+        if tool in ("pos_stanza",):
+            libs.append({"name": "stanza", "version": get_library_version("stanza")})
+
+    if tool == "length":
+        pass  # No external libs
+
+    return libs
+
+
+# ---------------------------------------------------------------------------
+# Manifest builder
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(
+    *,
+    tool_key: str,
+    language: Optional[str],
+    original_filename: str,
+    file_type: str,
+    row_count: int,
+    column_mapping: Dict[str, str],
+    added_columns: List[str],
+    libraries: List[Dict[str, str]],
+    timestamp: Optional[datetime] = None,
+    reproducibility: Optional[Dict[str, Any]] = None,
+    summary: Optional[Dict[str, Any]] = None,
+    sampling: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build a complete ``run_manifest.json`` dict.
+
+    Parameters
+    ----------
+    tool_key:
+        Registry key (e.g. ``"fa_g2p"``, ``"stratified"``).
+    language:
+        ISO language code or ``None`` for language-agnostic tools.
+    timestamp:
+        If ``None``, uses ``utc_now()``.
+    """
+    ts = timestamp or utc_now()
+    rkey = registry_key(language, tool_key) if language else tool_key
+    spec = TOOL_REGISTRY.get(rkey)
+    manifest_tool = spec.manifest_name if spec else tool_key
+
+    manifest: Dict[str, Any] = {
+        "lexprep_version": __version__,
+        "timestamp_utc": ts.isoformat(),
+        "tool": manifest_tool,
+        "citation": CITATION_INFO,
+        "input": {
+            "original_filename": original_filename,
+            "file_type": file_type,
+            "row_count": row_count,
+            "column_mapping": column_mapping,
+        },
+        "pipeline": {
+            "added_columns": added_columns,
+        },
+    }
+
+    # Only include language for language-specific tools
+    if language:
+        manifest["language"] = language
+
+    # Only include libraries when non-empty
+    if libraries:
+        manifest["pipeline"]["libraries"] = libraries
+
+    if reproducibility:
+        manifest["reproducibility"] = reproducibility
+    if summary:
+        manifest["summary"] = summary
+    if sampling:
+        manifest["sampling"] = sampling
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Manifest validation (for tests)
+# ---------------------------------------------------------------------------
+
+_REQUIRED_KEYS = {
+    "lexprep_version",
+    "timestamp_utc",
+    "tool",
+    "citation",
+    "input",
+    "pipeline",
+}
+_REQUIRED_INPUT_KEYS = {"original_filename", "file_type", "row_count", "column_mapping"}
+_REQUIRED_PIPELINE_KEYS = {"added_columns"}
+
+
+def validate_manifest(manifest: Dict[str, Any]) -> None:
+    """Raise ``ValueError`` if the manifest is structurally invalid."""
+    missing = _REQUIRED_KEYS - set(manifest.keys())
+    if missing:
+        raise ValueError(f"Missing top-level keys: {missing}")
+
+    missing_input = _REQUIRED_INPUT_KEYS - set(manifest.get("input", {}).keys())
+    if missing_input:
+        raise ValueError(f"Missing input keys: {missing_input}")
+
+    missing_pipeline = _REQUIRED_PIPELINE_KEYS - set(manifest.get("pipeline", {}).keys())
+    if missing_pipeline:
+        raise ValueError(f"Missing pipeline keys: {missing_pipeline}")
+
+    if not isinstance(manifest["input"]["row_count"], int):
+        raise ValueError("input.row_count must be an integer")

--- a/src/lexprep/packaging.py
+++ b/src/lexprep/packaging.py
@@ -1,0 +1,121 @@
+"""ZIP packaging for reproducibility packs (D1)."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from .manifest import format_timestamp_filename, sanitize_basename
+
+
+def make_zip_filename(
+    input_basename: str,
+    tool: str,
+    language: Optional[str],
+    timestamp: datetime,
+) -> str:
+    """Build ZIP filename per spec.
+
+    Pattern: ``{basename}__{tool}__{language}__{YYYYMMDDTHHMMSSZ}.zip``
+    """
+    safe_base = sanitize_basename(input_basename)
+    ts_str = format_timestamp_filename(timestamp)
+    lang = language or "all"
+    return f"{safe_base}__{tool}__{lang}__{ts_str}.zip"
+
+
+def make_output_filename(input_basename: str, ext: str, *, is_sampling: bool = False) -> str:
+    """Build main output filename inside the ZIP.
+
+    Language tools  → ``{basename}__enriched.{ext}``
+    Sampling        → ``{basename}__sample.{ext}``
+    """
+    safe_base = sanitize_basename(input_basename)
+    suffix = "__sample" if is_sampling else "__enriched"
+    return f"{safe_base}{suffix}.{ext}"
+
+
+# -----------------------------------------------------------------------
+# DataFrame serialisation
+# -----------------------------------------------------------------------
+
+
+def _df_to_bytes(df: pd.DataFrame, ext: str) -> bytes:
+    """Serialise a DataFrame to bytes in the given format."""
+    buf = io.BytesIO()
+    if ext == "csv":
+        df.to_csv(buf, index=False, encoding="utf-8-sig")
+    elif ext == "tsv":
+        df.to_csv(buf, index=False, sep="\t", encoding="utf-8-sig")
+    else:  # xlsx
+        df.to_excel(buf, index=False, engine="openpyxl")
+    buf.seek(0)
+    return buf.getvalue()
+
+
+# -----------------------------------------------------------------------
+# ZIP builder
+# -----------------------------------------------------------------------
+
+
+def build_zip(
+    *,
+    manifest: Dict[str, Any],
+    main_df: pd.DataFrame,
+    input_basename: str,
+    output_ext: str,
+    is_sampling: bool = False,
+    excluded_df: Optional[pd.DataFrame] = None,
+    audit_bytes: Optional[bytes] = None,
+    extra_files: Optional[List[Tuple[str, bytes]]] = None,
+) -> Tuple[bytes, str]:
+    """Build a ZIP reproducibility pack.
+
+    Files are written in a deterministic, fixed order so that identical
+    inputs always produce the same archive structure.
+
+    Returns
+    -------
+    (zip_bytes, zip_filename)
+    """
+    tool = manifest.get("tool", "unknown")
+    language = manifest.get("language")
+    ts = datetime.fromisoformat(manifest["timestamp_utc"])
+
+    zip_name = make_zip_filename(input_basename, tool, language, ts)
+    main_name = make_output_filename(input_basename, output_ext, is_sampling=is_sampling)
+    safe_base = sanitize_basename(input_basename)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # 1. run_manifest.json (always first)
+        zf.writestr(
+            "run_manifest.json",
+            json.dumps(manifest, indent=2, ensure_ascii=False),
+        )
+
+        # 2. Main output file (skip if empty, e.g. shuffle tools)
+        if not main_df.empty:
+            zf.writestr(main_name, _df_to_bytes(main_df, output_ext))
+
+        # 3. sampling_audit.xlsx (sampling only — deterministic order)
+        if audit_bytes is not None:
+            zf.writestr("sampling_audit.xlsx", audit_bytes)
+
+        # 4. excluded file (sampling only)
+        if excluded_df is not None:
+            excluded_name = f"{safe_base}__excluded.xlsx"
+            zf.writestr(excluded_name, _df_to_bytes(excluded_df, "xlsx"))
+
+        # 5. Extra files (e.g. shuffle outputs) — sorted for determinism
+        if extra_files:
+            for fname, fbytes in sorted(extra_files, key=lambda x: x[0]):
+                zf.writestr(fname, fbytes)
+
+    buf.seek(0)
+    return buf.getvalue(), zip_name

--- a/src/lexprep/sampling/audit.py
+++ b/src/lexprep/sampling/audit.py
@@ -1,0 +1,80 @@
+"""Sampling audit file and manifest section generation (D4.2, D4.3)."""
+
+from __future__ import annotations
+
+import io
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from .stratified import StratifiedSampleReport
+
+
+def build_audit_dataframe(report: StratifiedSampleReport) -> pd.DataFrame:
+    """Build one-row-per-bin audit summary table.
+
+    Columns: bin_id, min, max, population_size, selected_count,
+    excluded_count, allocation_method.
+    """
+    rows: List[Dict[str, Any]] = []
+    for s in report.strata:
+        rows.append(
+            {
+                "bin_id": s.index,
+                "min": s.lower,
+                "max": s.upper,
+                "population_size": s.count,
+                "selected_count": s.sampled,
+                "excluded_count": s.count - s.sampled,
+                "allocation_method": report.allocation_method,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def audit_to_bytes(report: StratifiedSampleReport) -> bytes:
+    """Generate ``sampling_audit.xlsx`` as bytes."""
+    df = build_audit_dataframe(report)
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def build_sampling_manifest_section(
+    report: StratifiedSampleReport,
+) -> Dict[str, Any]:
+    """Build the ``sampling`` section for ``run_manifest.json``.
+
+    Values such as ``bin_range_min`` / ``bin_range_max`` are kept as raw
+    floats (not rounded) for methodological accuracy.
+    """
+    bins: List[Dict[str, Any]] = []
+    selected_per_bin: List[int] = []
+    for s in report.strata:
+        bins.append(
+            {
+                "bin_id": s.index,
+                "bin_range_min": float(s.lower),
+                "bin_range_max": float(s.upper),
+                "population_size": s.count,
+            }
+        )
+        selected_per_bin.append(s.sampled)
+
+    return {
+        "variable": report.score_column,
+        "binning": {
+            "mode": ("quantiles" if report.stratification_type == "quantile" else "custom_ranges"),
+            "bins": bins,
+        },
+        "allocation": {
+            "method": report.allocation_method,
+            "formula_reference": "Cochran 1977",
+            "target_total_n": report.total_requested,
+        },
+        "result": {
+            "selected_per_bin": selected_per_bin,
+            "excluded_count": report.total_population - report.total_sampled,
+        },
+    }

--- a/src/lexprep/sampling/stratified.py
+++ b/src/lexprep/sampling/stratified.py
@@ -70,6 +70,15 @@ class StratifiedSampleReport:
 
 
 @dataclass
+class StratifiedSampleResult:
+    """Full result of stratified sampling, including excluded rows."""
+
+    sample_df: pd.DataFrame  # selected rows with bin_id column
+    excluded_df: pd.DataFrame  # non-selected rows with bin_id column
+    report: StratifiedSampleReport
+
+
+@dataclass
 class CustomRange:
     """User-defined range for custom stratification."""
     lower: float
@@ -538,3 +547,264 @@ def stratified_sample(
         weights=weights,
         random_state=random_state
     )
+
+
+# ---------------------------------------------------------------------------
+# Full variants — return sample + excluded + report (D4.1)
+# ---------------------------------------------------------------------------
+
+def _build_full_result(
+    df_work: pd.DataFrame,
+    sampled_parts: List[pd.DataFrame],
+    original_df: pd.DataFrame,
+    report: StratifiedSampleReport,
+) -> StratifiedSampleResult:
+    """Build a StratifiedSampleResult with bin_id on both sample and excluded."""
+    # Collect sampled original indices
+    sampled_indices = set()
+    for part in sampled_parts:
+        sampled_indices.update(part.index)
+
+    # Build sample DataFrame with bin_id
+    if sampled_parts:
+        result_df = pd.concat(sampled_parts, ignore_index=False)
+        result_df["bin_id"] = result_df["_stratum"].astype(int)
+        result_df = result_df.drop(columns=["_stratum", "_score"], errors="ignore")
+        result_df = result_df.reset_index(drop=True)
+    else:
+        result_df = original_df.iloc[0:0].copy()
+        result_df["bin_id"] = pd.Series(dtype="int")
+
+    # Build excluded DataFrame with bin_id
+    excluded_mask = ~df_work.index.isin(sampled_indices)
+    excluded_df = df_work[excluded_mask].copy()
+    if "_stratum" in excluded_df.columns:
+        excluded_df["bin_id"] = excluded_df["_stratum"].apply(
+            lambda x: int(x) if pd.notna(x) else -1
+        )
+    else:
+        excluded_df["bin_id"] = -1
+    excluded_df = excluded_df.drop(columns=["_stratum", "_score"], errors="ignore")
+    excluded_df = excluded_df.reset_index(drop=True)
+
+    return StratifiedSampleResult(
+        sample_df=result_df,
+        excluded_df=excluded_df,
+        report=report,
+    )
+
+
+def stratified_sample_quantiles_full(
+    df: pd.DataFrame,
+    *,
+    score_col: str,
+    n_total: int,
+    bins: int = 3,
+    allocation: Union[str, AllocationMethod] = AllocationMethod.EQUAL,
+    weights: Optional[Dict[int, float]] = None,
+    random_state: int = 19,
+) -> StratifiedSampleResult:
+    """Like ``stratified_sample_quantiles`` but returns sample + excluded + report."""
+    if isinstance(allocation, str):
+        allocation = AllocationMethod(allocation.lower())
+
+    if score_col not in df.columns:
+        raise ValueError(f"Column '{score_col}' not found. Available: {list(df.columns)}")
+
+    scores = pd.to_numeric(df[score_col], errors="coerce")
+    valid_mask = ~scores.isna()
+
+    if valid_mask.sum() == 0:
+        raise ValueError(f"Column '{score_col}' has no valid numeric values")
+
+    try:
+        bin_series, bin_edges = pd.qcut(
+            scores[valid_mask], q=bins, labels=False, retbins=True, duplicates="drop"
+        )
+    except ValueError as e:
+        raise ValueError(f"Cannot create {bins} quantile bins: {e}")
+
+    df_work = df.copy()
+    df_work["_stratum"] = pd.NA
+    df_work.loc[valid_mask, "_stratum"] = bin_series.values
+    df_work["_score"] = scores
+
+    actual_bins = int(bin_series.max()) + 1 if len(bin_series) > 0 else 0
+
+    strata = []
+    strata_sizes = {}
+    strata_stds = {}
+    warnings = []
+
+    for i in range(actual_bins):
+        stratum_data = df_work[df_work["_stratum"] == i]
+        stratum_scores = stratum_data["_score"]
+        lower = bin_edges[i] if i < len(bin_edges) else float("-inf")
+        upper = bin_edges[i + 1] if i + 1 < len(bin_edges) else float("inf")
+        stratum = Stratum(
+            index=i,
+            lower=lower,
+            upper=upper,
+            lower_inclusive=True,
+            upper_inclusive=(i == actual_bins - 1),
+            count=len(stratum_data),
+            mean=stratum_scores.mean() if len(stratum_data) > 0 else 0,
+            std=stratum_scores.std() if len(stratum_data) > 1 else 0,
+        )
+        strata.append(stratum)
+        strata_sizes[i] = stratum.count
+        strata_stds[i] = stratum.std
+
+    if actual_bins < bins:
+        warnings.append(
+            f"Requested {bins} bins, but only {actual_bins} could be created "
+            f"due to duplicate values in '{score_col}'. Some bins were merged."
+        )
+
+    allocated = _compute_allocation(strata_sizes, strata_stds, n_total, allocation, weights)
+
+    np.random.seed(random_state)
+    sampled_parts = []
+
+    for stratum in strata:
+        i = stratum.index
+        stratum_df = df_work[df_work["_stratum"] == i]
+        n_h = allocated.get(i, 0)
+        stratum.requested = n_h
+        if n_h > 0 and len(stratum_df) > 0:
+            sampled = stratum_df.sample(n=min(n_h, len(stratum_df)), random_state=random_state + i)
+            sampled_parts.append(sampled)
+            stratum.sampled = len(sampled)
+        else:
+            stratum.sampled = 0
+
+    total_sampled = sum(len(p) for p in sampled_parts)
+    if total_sampled < n_total:
+        diff = n_total - total_sampled
+        warnings.append(
+            f"Could not meet the requested sample size of {n_total}. "
+            f"Only {total_sampled} samples were available (shortfall: {diff})."
+        )
+
+    report = StratifiedSampleReport(
+        total_population=len(df),
+        total_requested=n_total,
+        total_sampled=total_sampled,
+        stratification_type=StratificationType.QUANTILE.value,
+        allocation_method=allocation.value,
+        strata_count=actual_bins,
+        strata=strata,
+        score_column=score_col,
+        random_seed=random_state,
+        weights_used=weights,
+        warnings=warnings,
+    )
+
+    return _build_full_result(df_work, sampled_parts, df, report)
+
+
+def stratified_sample_custom_ranges_full(
+    df: pd.DataFrame,
+    *,
+    score_col: str,
+    ranges: List[CustomRange],
+    n_total: Optional[int] = None,
+    allocation: Union[str, AllocationMethod] = AllocationMethod.EQUAL,
+    weights: Optional[Dict[int, float]] = None,
+    fixed_counts: Optional[Dict[int, int]] = None,
+    random_state: int = 19,
+) -> StratifiedSampleResult:
+    """Like ``stratified_sample_custom_ranges`` but returns sample + excluded + report."""
+    if isinstance(allocation, str):
+        allocation = AllocationMethod(allocation.lower())
+
+    if score_col not in df.columns:
+        raise ValueError(f"Column '{score_col}' not found. Available: {list(df.columns)}")
+
+    is_valid, error_msg = validate_custom_ranges(ranges)
+    if not is_valid:
+        raise ValueError(f"Invalid ranges: {error_msg}")
+
+    if allocation == AllocationMethod.FIXED:
+        if fixed_counts is None:
+            raise ValueError("fixed_counts required for FIXED allocation")
+        n_total = sum(fixed_counts.values())
+    elif n_total is None or n_total <= 0:
+        raise ValueError("n_total must be positive for non-FIXED allocation")
+
+    scores = pd.to_numeric(df[score_col], errors="coerce")
+
+    df_work = df.copy()
+    df_work["_stratum"] = pd.NA
+    df_work["_score"] = scores
+
+    for idx, custom_range in enumerate(ranges):
+        mask = df_work["_score"].apply(custom_range.contains)
+        unassigned = df_work["_stratum"].isna()
+        df_work.loc[mask & unassigned, "_stratum"] = idx
+
+    strata = []
+    strata_sizes = {}
+    strata_stds = {}
+    warnings = []
+
+    for idx, custom_range in enumerate(ranges):
+        stratum_data = df_work[df_work["_stratum"] == idx]
+        stratum_scores = stratum_data["_score"]
+        stratum = Stratum(
+            index=idx,
+            lower=custom_range.lower,
+            upper=custom_range.upper,
+            lower_inclusive=custom_range.lower_inclusive,
+            upper_inclusive=custom_range.upper_inclusive,
+            count=len(stratum_data),
+            mean=stratum_scores.mean() if len(stratum_data) > 0 else 0,
+            std=stratum_scores.std() if len(stratum_data) > 1 else 0,
+        )
+        strata.append(stratum)
+        strata_sizes[idx] = stratum.count
+        strata_stds[idx] = stratum.std
+
+    allocated = _compute_allocation(
+        strata_sizes, strata_stds, n_total, allocation, weights, fixed_counts
+    )
+
+    np.random.seed(random_state)
+    sampled_parts = []
+
+    for stratum in strata:
+        i = stratum.index
+        stratum_df = df_work[df_work["_stratum"] == i]
+        n_h = allocated.get(i, 0)
+        stratum.requested = n_h
+        if n_h > 0 and len(stratum_df) > 0:
+            actual_n = min(n_h, len(stratum_df))
+            sampled = stratum_df.sample(n=actual_n, random_state=random_state + i)
+            sampled_parts.append(sampled)
+            stratum.sampled = len(sampled)
+        else:
+            stratum.sampled = 0
+
+    total_sampled = sum(len(p) for p in sampled_parts)
+    if n_total is not None and total_sampled < n_total:
+        diff = n_total - total_sampled
+        warnings.append(
+            f"Could not meet the requested sample size of {n_total}. "
+            f"Only {total_sampled} samples were available (shortfall: {diff})."
+        )
+
+    report = StratifiedSampleReport(
+        total_population=len(df),
+        total_requested=n_total,
+        total_sampled=total_sampled,
+        stratification_type=StratificationType.CUSTOM.value,
+        allocation_method=allocation.value,
+        strata_count=len(ranges),
+        strata=strata,
+        score_column=score_col,
+        random_seed=random_state,
+        weights_used=weights,
+        warnings=warnings,
+    )
+
+    return _build_full_result(df_work, sampled_parts, df, report)

--- a/tests/test_length.py
+++ b/tests/test_length.py
@@ -1,0 +1,72 @@
+"""Tests for lexprep.length module (D3)."""
+
+from lexprep.length import (
+    LENGTH_METHOD,
+    LengthDistribution,
+    compute_length_chars,
+    length_distribution,
+)
+
+
+class TestComputeLengthChars:
+    def test_ascii(self):
+        assert compute_length_chars(["hello", "world"]) == [5, 5]
+
+    def test_persian(self):
+        # «سلام» = 4 characters
+        assert compute_length_chars(["سلام"]) == [4]
+
+    def test_japanese(self):
+        # «東京» = 2 characters
+        assert compute_length_chars(["東京"]) == [2]
+
+    def test_empty_string(self):
+        assert compute_length_chars([""]) == [0]
+
+    def test_whitespace_only(self):
+        assert compute_length_chars(["   "]) == [0]
+
+    def test_mixed(self):
+        result = compute_length_chars(["abc", "", "سلام", "  "])
+        assert result == [3, 0, 4, 0]
+
+    def test_unicode_emoji(self):
+        # Emoji is 1 codepoint
+        assert compute_length_chars(["😀"]) == [1]
+
+
+class TestLengthDistribution:
+    def test_basic(self):
+        dist = length_distribution([3, 5, 7])
+        assert dist is not None
+        assert dist.min == 3
+        assert dist.max == 7
+        assert dist.mean == 5.0
+        assert dist.median == 5.0
+
+    def test_all_zeros(self):
+        assert length_distribution([0, 0, 0]) is None
+
+    def test_empty_list(self):
+        assert length_distribution([]) is None
+
+    def test_single_value(self):
+        dist = length_distribution([4])
+        assert dist.min == 4
+        assert dist.max == 4
+
+    def test_with_zeros_filtered(self):
+        dist = length_distribution([0, 3, 0, 5])
+        assert dist is not None
+        assert dist.min == 3
+        assert dist.max == 5
+
+    def test_to_dict(self):
+        dist = LengthDistribution(min=1, max=10, mean=5.0, median=5.0)
+        d = dist.to_dict()
+        assert d == {"min": 1, "max": 10, "mean": 5.0, "median": 5.0}
+
+
+class TestLengthMethod:
+    def test_method_string(self):
+        assert LENGTH_METHOD == "unicode_codepoints"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,188 @@
+"""Tests for lexprep.manifest module (D2)."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from lexprep.manifest import (
+    CITATION_INFO,
+    TOOL_REGISTRY,
+    build_manifest,
+    format_timestamp_filename,
+    get_library_version,
+    registry_key,
+    sanitize_basename,
+    utc_now,
+    validate_manifest,
+)
+
+
+class TestToolRegistry:
+    def test_all_keys_have_manifest_name(self):
+        for key, spec in TOOL_REGISTRY.items():
+            assert spec.manifest_name, f"No manifest_name for {key}"
+
+    def test_registry_key_with_language(self):
+        assert registry_key("fa", "g2p") == "fa_g2p"
+        assert registry_key("en", "pos") == "en_pos"
+
+    def test_registry_key_without_language(self):
+        assert registry_key(None, "stratified") == "stratified"
+        assert registry_key(None, "shuffle") == "shuffle"
+
+    def test_registry_key_fallback(self):
+        assert registry_key("fa", "length") == "length"
+
+
+class TestTimestamp:
+    def test_utc_now_is_utc(self):
+        ts = utc_now()
+        assert ts.tzinfo == timezone.utc
+
+    def test_format_timestamp_filename(self):
+        ts = datetime(2026, 2, 20, 14, 30, 0, tzinfo=timezone.utc)
+        assert format_timestamp_filename(ts) == "20260220T143000Z"
+
+
+class TestSanitizeBasename:
+    def test_normal_name(self):
+        assert sanitize_basename("wordlist") == "wordlist"
+
+    def test_spaces(self):
+        assert sanitize_basename("my file") == "my_file"
+
+    def test_special_chars(self):
+        assert sanitize_basename('file<>:"/name') == "file_name"
+
+    def test_empty(self):
+        assert sanitize_basename("") == "output"
+
+
+class TestBuildManifest:
+    def _make_manifest(self, **kwargs):
+        defaults = {
+            "tool_key": "g2p",
+            "language": "fa",
+            "original_filename": "test.xlsx",
+            "file_type": "xlsx",
+            "row_count": 100,
+            "column_mapping": {"word_column": "word"},
+            "added_columns": ["pronunciation"],
+            "libraries": [{"name": "PersianG2p", "version": "0.1.5"}],
+        }
+        defaults.update(kwargs)
+        return build_manifest(**defaults)
+
+    def test_required_fields_present(self):
+        m = self._make_manifest()
+        validate_manifest(m)  # Should not raise
+
+    def test_tool_name_mapped(self):
+        m = self._make_manifest(tool_key="g2p", language="fa")
+        assert m["tool"] == "g2p"
+
+    def test_syllable_tool_mapped(self):
+        m = self._make_manifest(tool_key="syllables", language="en")
+        assert m["tool"] == "syllable_count"
+
+    def test_pos_tool_mapped(self):
+        m = self._make_manifest(tool_key="pos", language="fa")
+        assert m["tool"] == "pos_tagging"
+
+    def test_version_present(self):
+        m = self._make_manifest()
+        assert m["lexprep_version"] == "1.0.0"
+
+    def test_timestamp_utc(self):
+        m = self._make_manifest()
+        assert "T" in m["timestamp_utc"]
+
+    def test_citation_present(self):
+        m = self._make_manifest()
+        assert m["citation"]["doi"] == "10.5281/zenodo.18713755"
+
+    def test_input_section(self):
+        m = self._make_manifest()
+        assert m["input"]["original_filename"] == "test.xlsx"
+        assert m["input"]["row_count"] == 100
+
+    def test_optional_fields_omitted_when_none(self):
+        m = self._make_manifest()
+        assert "reproducibility" not in m
+        assert "summary" not in m
+        assert "sampling" not in m
+
+    def test_optional_fields_included_when_set(self):
+        m = self._make_manifest(
+            reproducibility={"seed": 42},
+            summary={"pos_distribution": {"NOUN": 10}},
+        )
+        assert m["reproducibility"]["seed"] == 42
+        assert "pos_distribution" in m["summary"]
+
+
+class TestValidateManifest:
+    def test_valid(self):
+        m = build_manifest(
+            tool_key="g2p",
+            language="fa",
+            original_filename="test.xlsx",
+            file_type="xlsx",
+            row_count=10,
+            column_mapping={},
+            added_columns=[],
+            libraries=[],
+        )
+        validate_manifest(m)  # Should not raise
+
+    def test_missing_top_level(self):
+        with pytest.raises(ValueError, match="Missing top-level"):
+            validate_manifest({"tool": "g2p"})
+
+    def test_row_count_must_be_int(self):
+        m = build_manifest(
+            tool_key="g2p",
+            language="fa",
+            original_filename="t.xlsx",
+            file_type="xlsx",
+            row_count=10,
+            column_mapping={},
+            added_columns=[],
+            libraries=[],
+        )
+        m["input"]["row_count"] = "10"
+        with pytest.raises(ValueError, match="row_count"):
+            validate_manifest(m)
+
+
+class TestCitationSync:
+    """Ensure hardcoded CITATION_INFO matches CITATION.cff."""
+
+    def test_doi_matches_cff(self):
+        import pathlib
+
+        cff_path = pathlib.Path(__file__).parent.parent / "CITATION.cff"
+        if not cff_path.exists():
+            pytest.skip("CITATION.cff not found")
+        content = cff_path.read_text(encoding="utf-8")
+        # Check DOI is present in the CFF file
+        assert CITATION_INFO["doi"] in content
+
+    def test_url_matches_cff(self):
+        import pathlib
+
+        cff_path = pathlib.Path(__file__).parent.parent / "CITATION.cff"
+        if not cff_path.exists():
+            pytest.skip("CITATION.cff not found")
+        content = cff_path.read_text(encoding="utf-8")
+        assert CITATION_INFO["url"] in content
+
+
+class TestGetLibraryVersion:
+    def test_known_package(self):
+        ver = get_library_version("pandas")
+        assert ver != "unknown"
+
+    def test_unknown_package(self):
+        ver = get_library_version("nonexistent_package_12345")
+        assert ver == "unknown"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,175 @@
+"""Tests for lexprep.packaging module (D1)."""
+
+import json
+import zipfile
+from datetime import datetime, timezone
+from io import BytesIO
+
+import pandas as pd
+
+from lexprep.manifest import build_manifest
+from lexprep.packaging import build_zip, make_output_filename, make_zip_filename
+
+
+class TestMakeZipFilename:
+    def test_basic(self):
+        ts = datetime(2026, 2, 20, 14, 30, 0, tzinfo=timezone.utc)
+        name = make_zip_filename("wordlist", "g2p", "fa", ts)
+        assert name == "wordlist__g2p__fa__20260220T143000Z.zip"
+
+    def test_no_language(self):
+        ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        name = make_zip_filename("data", "row_shuffle", None, ts)
+        assert name == "data__row_shuffle__all__20260101T000000Z.zip"
+
+    def test_sanitized_basename(self):
+        ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        name = make_zip_filename("my file", "g2p", "en", ts)
+        assert "my_file" in name
+        assert " " not in name
+
+
+class TestMakeOutputFilename:
+    def test_enriched(self):
+        assert make_output_filename("wordlist", "xlsx") == "wordlist__enriched.xlsx"
+
+    def test_sample(self):
+        assert make_output_filename("data", "xlsx", is_sampling=True) == "data__sample.xlsx"
+
+    def test_csv(self):
+        assert make_output_filename("words", "csv") == "words__enriched.csv"
+
+
+class TestBuildZip:
+    def _make_manifest(self, tool="g2p", language="fa"):
+        return build_manifest(
+            tool_key=tool,
+            language=language,
+            original_filename="test.xlsx",
+            file_type="xlsx",
+            row_count=3,
+            column_mapping={"word_column": "word"},
+            added_columns=["pronunciation"],
+            libraries=[],
+        )
+
+    def test_basic_zip_structure(self):
+        manifest = self._make_manifest()
+        df = pd.DataFrame({"word": ["a", "b"], "pronunciation": ["x", "y"]})
+        zip_bytes, zip_name = build_zip(
+            manifest=manifest,
+            main_df=df,
+            input_basename="test",
+            output_ext="xlsx",
+        )
+        assert zip_name.endswith(".zip")
+        assert "__g2p__fa__" in zip_name
+
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            assert "run_manifest.json" in names
+            assert "test__enriched.xlsx" in names
+            assert len(names) == 2
+
+    def test_manifest_is_valid_json(self):
+        manifest = self._make_manifest()
+        df = pd.DataFrame({"word": ["a"]})
+        zip_bytes, _ = build_zip(
+            manifest=manifest,
+            main_df=df,
+            input_basename="test",
+            output_ext="xlsx",
+        )
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            data = json.loads(zf.read("run_manifest.json"))
+            assert data["tool"] == "g2p"
+            assert data["language"] == "fa"
+
+    def test_sampling_zip_structure(self):
+        manifest = build_manifest(
+            tool_key="stratified",
+            language=None,
+            original_filename="data.xlsx",
+            file_type="xlsx",
+            row_count=100,
+            column_mapping={"score_column": "freq"},
+            added_columns=["bin_id"],
+            libraries=[],
+        )
+        sample_df = pd.DataFrame({"word": ["a"], "bin_id": [0]})
+        excluded_df = pd.DataFrame({"word": ["b"], "bin_id": [1]})
+        audit_bytes = b"fake audit data"
+
+        zip_bytes, zip_name = build_zip(
+            manifest=manifest,
+            main_df=sample_df,
+            input_basename="data",
+            output_ext="xlsx",
+            is_sampling=True,
+            excluded_df=excluded_df,
+            audit_bytes=audit_bytes,
+        )
+
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            assert "run_manifest.json" in names
+            assert "data__sample.xlsx" in names
+            assert "sampling_audit.xlsx" in names
+            assert "data__excluded.xlsx" in names
+            assert len(names) == 4
+
+    def test_extra_files_sorted(self):
+        manifest = self._make_manifest(tool="shuffle", language=None)
+        manifest["tool"] = "row_shuffle"  # Override since language=None
+        zip_bytes, _ = build_zip(
+            manifest=manifest,
+            main_df=pd.DataFrame(),
+            input_basename="shuffle",
+            output_ext="xlsx",
+            extra_files=[("b_shuffled.xlsx", b"b"), ("a_shuffled.xlsx", b"a")],
+        )
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            # Extra files should be sorted
+            extra = [n for n in names if n.endswith("_shuffled.xlsx")]
+            assert extra == ["a_shuffled.xlsx", "b_shuffled.xlsx"]
+
+    def test_output_filename_pattern_enriched(self):
+        manifest = self._make_manifest()
+        df = pd.DataFrame({"word": ["a"]})
+        zip_bytes, _ = build_zip(
+            manifest=manifest,
+            main_df=df,
+            input_basename="mywords",
+            output_ext="csv",
+        )
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            assert "mywords__enriched.csv" in zf.namelist()
+
+    def test_output_filename_pattern_sample(self):
+        manifest = self._make_manifest()
+        df = pd.DataFrame({"word": ["a"]})
+        zip_bytes, _ = build_zip(
+            manifest=manifest,
+            main_df=df,
+            input_basename="mydata",
+            output_ext="xlsx",
+            is_sampling=True,
+        )
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            assert "mydata__sample.xlsx" in zf.namelist()
+
+    def test_deterministic_file_order(self):
+        """ZIP should have files in a consistent order."""
+        manifest = self._make_manifest()
+        df = pd.DataFrame({"word": ["a"]})
+        zip_bytes, _ = build_zip(
+            manifest=manifest,
+            main_df=df,
+            input_basename="test",
+            output_ext="xlsx",
+        )
+        with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            assert names[0] == "run_manifest.json"
+            assert names[1] == "test__enriched.xlsx"

--- a/tests/test_sampling_audit.py
+++ b/tests/test_sampling_audit.py
@@ -1,0 +1,229 @@
+"""Tests for lexprep.sampling.audit module (D4)."""
+
+import json
+
+import pandas as pd
+
+from lexprep.sampling.audit import (
+    audit_to_bytes,
+    build_audit_dataframe,
+    build_sampling_manifest_section,
+)
+from lexprep.sampling.stratified import (
+    StratifiedSampleReport,
+    StratifiedSampleResult,
+    Stratum,
+    stratified_sample_quantiles_full,
+)
+
+
+def _make_report():
+    """Create a sample report for testing."""
+    strata = [
+        Stratum(
+            index=0,
+            lower=1.0,
+            upper=5.0,
+            count=30,
+            mean=3.0,
+            std=1.0,
+            requested=10,
+            sampled=10,
+        ),
+        Stratum(
+            index=1,
+            lower=5.0,
+            upper=10.0,
+            count=50,
+            mean=7.5,
+            std=1.5,
+            requested=10,
+            sampled=10,
+        ),
+        Stratum(
+            index=2,
+            lower=10.0,
+            upper=20.0,
+            count=20,
+            mean=15.0,
+            std=3.0,
+            requested=10,
+            sampled=10,
+        ),
+    ]
+    return StratifiedSampleReport(
+        total_population=100,
+        total_requested=30,
+        total_sampled=30,
+        stratification_type="quantile",
+        allocation_method="equal",
+        strata_count=3,
+        strata=strata,
+        score_column="frequency",
+        random_seed=42,
+    )
+
+
+class TestBuildAuditDataframe:
+    def test_columns(self):
+        report = _make_report()
+        df = build_audit_dataframe(report)
+        expected_cols = {
+            "bin_id",
+            "min",
+            "max",
+            "population_size",
+            "selected_count",
+            "excluded_count",
+            "allocation_method",
+        }
+        assert set(df.columns) == expected_cols
+
+    def test_row_count(self):
+        report = _make_report()
+        df = build_audit_dataframe(report)
+        assert len(df) == 3
+
+    def test_consistency_selected_plus_excluded(self):
+        """selected_count + excluded_count should equal population_size."""
+        report = _make_report()
+        df = build_audit_dataframe(report)
+        for _, row in df.iterrows():
+            assert row["selected_count"] + row["excluded_count"] == row["population_size"]
+
+    def test_total_population_matches(self):
+        """Sum of population_size across bins should match total_population."""
+        report = _make_report()
+        df = build_audit_dataframe(report)
+        assert df["population_size"].sum() == report.total_population
+
+    def test_bin_range_values_are_numeric(self):
+        report = _make_report()
+        df = build_audit_dataframe(report)
+        assert df["min"].dtype in ("float64", "int64")
+        assert df["max"].dtype in ("float64", "int64")
+
+
+class TestAuditToBytes:
+    def test_returns_bytes(self):
+        report = _make_report()
+        data = audit_to_bytes(report)
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_is_valid_xlsx(self):
+        report = _make_report()
+        data = audit_to_bytes(report)
+        import io
+
+        df = pd.read_excel(io.BytesIO(data))
+        assert "bin_id" in df.columns
+        assert len(df) == 3
+
+
+class TestBuildSamplingManifestSection:
+    def test_structure(self):
+        report = _make_report()
+        section = build_sampling_manifest_section(report)
+        assert section["variable"] == "frequency"
+        assert section["binning"]["mode"] == "quantiles"
+        assert len(section["binning"]["bins"]) == 3
+        assert section["allocation"]["method"] == "equal"
+        assert section["allocation"]["target_total_n"] == 30
+        assert len(section["result"]["selected_per_bin"]) == 3
+
+    def test_bin_range_values_not_rounded(self):
+        """bin_range_min and bin_range_max must be exact floats."""
+        report = _make_report()
+        section = build_sampling_manifest_section(report)
+        for b in section["binning"]["bins"]:
+            assert isinstance(b["bin_range_min"], float)
+            assert isinstance(b["bin_range_max"], float)
+
+    def test_excluded_count_consistent(self):
+        report = _make_report()
+        section = build_sampling_manifest_section(report)
+        assert section["result"]["excluded_count"] == report.total_population - report.total_sampled
+
+    def test_json_serializable(self):
+        report = _make_report()
+        section = build_sampling_manifest_section(report)
+        # Should not raise
+        json.dumps(section)
+
+
+class TestStratifiedSampleFull:
+    def _make_df(self, n=100):
+        import numpy as np
+
+        np.random.seed(42)
+        return pd.DataFrame(
+            {
+                "word": [f"w{i}" for i in range(n)],
+                "freq": np.random.uniform(1, 100, n),
+            }
+        )
+
+    def test_returns_result_type(self):
+        df = self._make_df()
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=30,
+            bins=3,
+        )
+        assert isinstance(result, StratifiedSampleResult)
+
+    def test_bin_id_in_sample(self):
+        df = self._make_df()
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=30,
+            bins=3,
+        )
+        assert "bin_id" in result.sample_df.columns
+
+    def test_bin_id_in_excluded(self):
+        df = self._make_df()
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=30,
+            bins=3,
+        )
+        assert "bin_id" in result.excluded_df.columns
+
+    def test_sample_plus_excluded_equals_population(self):
+        df = self._make_df()
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=30,
+            bins=3,
+        )
+        total = len(result.sample_df) + len(result.excluded_df)
+        assert total == len(df)
+
+    def test_no_overlap_between_sample_and_excluded(self):
+        df = self._make_df()
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=30,
+            bins=3,
+        )
+        # Check no duplicate words
+        sample_words = set(result.sample_df["word"].tolist())
+        excluded_words = set(result.excluded_df["word"].tolist())
+        assert len(sample_words & excluded_words) == 0
+
+    def test_report_population_matches(self):
+        df = self._make_df(50)
+        result = stratified_sample_quantiles_full(
+            df,
+            score_col="freq",
+            n_total=15,
+            bins=3,
+        )
+        assert result.report.total_population == 50


### PR DESCRIPTION
- manifest.py: run_manifest.json generator with tool registry, citation, validation
- packaging.py: ZIP reproducibility pack builder (deterministic file order)
- length.py: language-agnostic length_chars (Unicode codepoint count)
- sampling/audit.py: per-bin audit report and manifest section
- sampling/stratified.py: full result variants returning sample + excluded + report

Refs #1, #2, #3, #4, #5